### PR TITLE
Fix clone to indicate --prefix

### DIFF
--- a/sync2git
+++ b/sync2git
@@ -69,6 +69,7 @@ do
     echo "First run, doing a full git-svn clone, this may take a while..."
     git svn clone \
       "${SVN_REPO}" \
+      --prefix=origin/ \
       -A "${AUTHORS_FILE}" \
       ${SVN_LAYOUT} \
       "${SVN_CLONE}"


### PR DESCRIPTION
Clone must indicate --prefix value for following logic to work reliably. Not including the flag breaks backward compatibility with git prior to 2.0.
